### PR TITLE
Fix `ModuleNotFoundError: No module named 'urlparse'` in Python3

### DIFF
--- a/redquery/__init__.py
+++ b/redquery/__init__.py
@@ -1,4 +1,8 @@
-from urlparse import urljoin
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
+
 import json
 import time
 


### PR DESCRIPTION
Thanks for your great project. 

In Python 3 env, raised error like: `ModuleNotFoundError: No module named 'urlparse'`. 
This PR is modification for the error.